### PR TITLE
silently ignore correspawn and armrespawn (dunno if this is desired behaviour, but otherwise crashed for me)

### DIFF
--- a/bar_units.py
+++ b/bar_units.py
@@ -82,6 +82,10 @@ def main(filters, selection):
     # parseout all the files and create a giant dictionary
     # use intermediate format to create both a raw output and a extended output
     unitTupleList = [parse.eval_string(unitFile) for unitFile in unitFiles]
+
+    while None in unitTupleList:
+        unitTupleList.remove(None)
+
     rawUnits = {id: value for id, value in unitTupleList}
 
     # write the json to disk

--- a/src/parse.py
+++ b/src/parse.py
@@ -43,10 +43,11 @@ def eval_string(path):
             print("found broken thing at " + path)
         return open_unit_table(data)
     except lupa._lupa.LuaError as e:
-        print("encountered the following error while parsing " + path)
-        print(e.message)
-        if "attempt to index a nil value" in e.args[0]:
+        if "attempt to index a nil value" in e.args[0] or (
+                "attempt to index global" in e.args[0] and "(a nil value)" in e.args[0]):
             return None
+        print("encountered the following error while parsing " + path)
+        print(e)
         raise
 
 


### PR DESCRIPTION
They would produce following error

encountered the following error while parsing ./repo/units/Scavengers/Buildings/Factories/armrespawn.lua [string "<python>"]:1: attempt to index global 'Spring' (a nil value) stack traceback:
	[string "<python>"]:1: in main chunk
encountered the following error while parsing ./repo/units/Scavengers/Buildings/Factories/correspawn.lua [string "<python>"]:1: attempt to index global 'Spring' (a nil value) stack traceback:
	[string "<python>"]:1: in main chunk